### PR TITLE
Nested key support in maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ npm install --save react-map-props
 
 ## Usage
 
-The `mapProps()` function accepts either an object hash containing transforms for only the properies you want, or you can provide a function that will accept all of the `props` at once and is expected to then return the desired `props`.
+The `mapProps()` function accepts either an object hash containing transforms
+for only the properies you want, or you can provide a function that will
+accept all of the `props` at once and is expected to then return the desired `props`.
 
 ```js
 @mapProps({
   message: value => value + ' world'
+})
+
+// or recursively
+
+```js
+@mapProps({
+  message: {
+    key: value => value + ' world'
+  },
 })
 
 // or

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-router": "^2.3.0",
+    "react-test-renderer": "^16.6.1",
     "rimraf": "^2.5.2",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1"

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const applyTransform = (transform, props) => {
     const nextProps = {...props };
 
     for (const key in transform) {
-      nextProps[key] = transform[key](props[key]);
+      nextProps[key] = applyTransform(transform[key], props[key])
     }
 
     return nextProps;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,9 @@ const applyTransform = (transform, props) => {
     const nextProps = {...props };
 
     for (const key in transform) {
-      nextProps[key] = applyTransform(transform[key], props[key])
+      if (key in props) {
+        nextProps[key] = applyTransform(transform[key], props[key])
+      }
     }
 
     return nextProps;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,31 @@
+import ShallowRenderer from 'react-test-renderer/shallow';
 import expect from 'expect';
-import { provideQueryParams } from '../src';
+import React from 'react'
+import { mapProps } from '../src';
+
+function MyComponent(props) {
+  return <div>{props.foo}</div>
+}
+
+const NullMappedComponent = mapProps({})(MyComponent)
+const MappedComponent = mapProps({foo: value => 4})(MyComponent)
 
 describe('provideQueryParams', () => {
-  it.skip('should work #YOLO', () => {
-    
+  it('does not change prop when map is empty', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<NullMappedComponent foo='1' />);
+    const result = renderer.getRenderOutput();
+
+    expect(result.type).toBe(MyComponent);
+    expect(result.props.foo).toEqual(1)
+  });
+  
+  it('changes prop when map is a hash', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<MappedComponent foo='1' />);
+    const result = renderer.getRenderOutput();
+
+    expect(result.type).toBe(MyComponent);
+    expect(result.props.foo).toEqual(4)
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -9,6 +9,7 @@ function MyComponent(props) {
 
 const NullMappedComponent = mapProps({})(MyComponent)
 const MappedComponent = mapProps({foo: value => value*2})(MyComponent)
+const DeepMappedComponent = mapProps({foo: {bar: value => value*2}})(MyComponent)
 const FnMappedComponent = mapProps(value => ({foo: value}))(MyComponent)
 
 describe('provideQueryParams', () => {
@@ -28,6 +29,15 @@ describe('provideQueryParams', () => {
 
     expect(result.type).toBe(MyComponent);
     expect(result.props.foo).toEqual(2)
+  });
+  
+  it('changes prop when map is a deep hash', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<DeepMappedComponent foo={{bar: '1'}} />);
+    const result = renderer.getRenderOutput();
+
+    expect(result.type).toBe(MyComponent);
+    expect(result.props.foo).toEqual({bar: 2})
   });
   
   it('changes prop when map is a function', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,7 +8,8 @@ function MyComponent(props) {
 }
 
 const NullMappedComponent = mapProps({})(MyComponent)
-const MappedComponent = mapProps({foo: value => 4})(MyComponent)
+const MappedComponent = mapProps({foo: value => value*2})(MyComponent)
+const FnMappedComponent = mapProps(value => ({foo: value}))(MyComponent)
 
 describe('provideQueryParams', () => {
   it('does not change prop when map is empty', () => {
@@ -26,6 +27,15 @@ describe('provideQueryParams', () => {
     const result = renderer.getRenderOutput();
 
     expect(result.type).toBe(MyComponent);
-    expect(result.props.foo).toEqual(4)
+    expect(result.props.foo).toEqual(2)
+  });
+  
+  it('changes prop when map is a function', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<FnMappedComponent bar='1' />);
+    const result = renderer.getRenderOutput();
+
+    expect(result.type).toBe(MyComponent);
+    expect(result.props.foo).toEqual({bar: '1'})
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,6 +40,16 @@ describe('provideQueryParams', () => {
     expect(result.props.foo).toEqual({bar: 2})
   });
   
+  it('is noop when map is a deep hash and lacks the referenced key', () => {
+    const renderer = new ShallowRenderer();
+    renderer.render(<DeepMappedComponent quux={{bar: '1'}} />);
+    const result = renderer.getRenderOutput();
+
+    expect(result.type).toBe(MyComponent);
+    expect(result.props.foo).toBe(undefined)
+    expect(result.props.quux).toEqual({bar: '1'})
+  });
+  
   it('changes prop when map is a function', () => {
     const renderer = new ShallowRenderer();
     renderer.render(<FnMappedComponent bar='1' />);


### PR DESCRIPTION
Thanks for this library, it works great for urlunescaping path segments I get from react-easy-router.

One addition I found handy was ability to map keys below top level, as router params exist under props.params.foo. I made this patch with tests & docs.